### PR TITLE
Added options for gravity and ground requirements in Leap, Added Felinid speech verbs

### DIFF
--- a/Content.Shared/Leap/LeapComponent.cs
+++ b/Content.Shared/Leap/LeapComponent.cs
@@ -22,6 +22,7 @@ namespace Content.Shared.Leap
         [DataField("duration")]
         public float Duration = 1f;
 
+        // Speed entity is set to during leap
         [DataField("speed")]
         public float Speed = 5f;
 
@@ -36,9 +37,6 @@ namespace Content.Shared.Leap
 
         [ViewVariables]
         public bool CheckColliding = false;
-
-        [ViewVariables]
-        public TimeSpan CompleteTime = TimeSpan.FromSeconds(0);
 
         public sealed partial class LeapForwardEvent : InstantActionEvent { }
     }

--- a/Content.Shared/Leap/LeapComponent.cs
+++ b/Content.Shared/Leap/LeapComponent.cs
@@ -26,6 +26,15 @@ namespace Content.Shared.Leap
         [DataField("speed")]
         public float Speed = 5f;
 
+        // Whether this entity should be able to leap in no gravity environments
+        [DataField("requiresGravity")]
+        public bool RequiresGravity = false; //Magboots do count as having gravity
+
+        // Whether this entity should be able to leap if there is no surface nearby, used if the gravity requirement is false
+        [DataField("requiresGrounded")]
+        public bool RequiresGrounded = true;
+
+        // The stamina that will be used up in a leap
         [DataField("staminaCost")]
         public int StaminaCost = 20;
 

--- a/Content.Shared/Leap/LeapSystem.cs
+++ b/Content.Shared/Leap/LeapSystem.cs
@@ -35,7 +35,7 @@ public sealed class LeapSystem : EntitySystem
     private const int LeapingCollisionGroup = (int) (CollisionGroup.TableLayer | CollisionGroup.LowImpassable);
     private const string LeapingFixtureName = "Leaping";
 
-    private readonly Dictionary<EntityUid, Dictionary<string,Fixture>> _fixtureRemoveQueue = new();
+    private readonly Dictionary<EntityUid, Dictionary<string, Fixture>> _fixtureRemoveQueue = new();
 
     public override void Initialize()
     {
@@ -78,8 +78,7 @@ public sealed class LeapSystem : EntitySystem
     private bool AttemptLeap(EntityUid uid,
     LeapComponent? leapComp = null,
     PhysicsComponent? physicsComp = null,
-    FixturesComponent? fixtureComp = null,
-    ClimbingComponent? climbingComp = null)
+    FixturesComponent? fixtureComp = null)
     {
 
         if (!Resolve(uid, ref fixtureComp, ref physicsComp, ref leapComp))
@@ -112,7 +111,8 @@ public sealed class LeapSystem : EntitySystem
             _physics.SetCollisionMask(uid, name, fixture, fixture.CollisionMask & ~LeapingCollisionGroup, fixtureComp);
         }
 
-        if (!fixtureComp.Fixtures.ContainsKey(LeapingFixtureName)){
+        if (!fixtureComp.Fixtures.ContainsKey(LeapingFixtureName))
+        {
             if (!_fixtureSystem.TryCreateFixture(
                     uid,
                     new PhysShapeCircle(0.35f),
@@ -173,8 +173,6 @@ public sealed class LeapSystem : EntitySystem
 
         foreach (var entities in contactingEntities)
         {
-            //if (fixture == args.OtherFixture)
-            //continue;
             if (HasComp<ClimbableComponent>(entities))
                 return;
         }
@@ -204,15 +202,10 @@ public sealed class LeapSystem : EntitySystem
         leapComp.Jumping = false;
         leapComp.CheckColliding = false;
 
-        //ClimbingComponent? climbingComp = null;
-
-        //if(Resolve(uid, ref climbingComp))
-            //climbingComp.IsClimbing = false;
-
         ReturnLeapCollisions(uid, leapComp);
     }
 
-    private void ReturnLeapCollisions(EntityUid uid, LeapComponent? leapComp = null, FixturesComponent? fixtures = null, ClimbingComponent? climbComp = null)
+    private void ReturnLeapCollisions(EntityUid uid, LeapComponent? leapComp = null, FixturesComponent? fixtures = null)
     {
         if (!Resolve(uid, ref fixtures, ref leapComp))
             return;
@@ -230,15 +223,12 @@ public sealed class LeapSystem : EntitySystem
 
         if (!_fixtureRemoveQueue.TryGetValue(uid, out var removeQueue))
         {
-            removeQueue = new Dictionary<string,Fixture>();
+            removeQueue = new Dictionary<string, Fixture>();
             _fixtureRemoveQueue.Add(uid, removeQueue);
         }
 
         if (fixtures.Fixtures.TryGetValue(LeapingFixtureName, out var leapingFixture))
             removeQueue.Add(LeapingFixtureName, leapingFixture);
-
-        //if (Resolve(uid, ref climbComp))
-        //    climbComp.IsClimbing = false;
     }
 
     public override void Update(float frameTime)

--- a/Resources/Locale/en-US/chat/managers/chat-manager.ftl
+++ b/Resources/Locale/en-US/chat/managers/chat-manager.ftl
@@ -63,6 +63,8 @@ chat-speech-verb-insect-2 = flutters
 
 chat-speech-verb-slime = chirps
 
+chat-speech-verb-felinid = mews
+
 chat-speech-verb-robotic = states
 chat-speech-verb-reptilian = hisses
 

--- a/Resources/Prototypes/Entities/Mobs/Species/felinid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/felinid.yml
@@ -60,6 +60,7 @@
   - type: Perishable
   - type: Speech
     speechSounds: Felinid
+    speechVerb: Felinid
   - type: Leap
     duration: 0.5
   - type: Butcherable

--- a/Resources/Prototypes/Voice/speech_verbs.yml
+++ b/Resources/Prototypes/Voice/speech_verbs.yml
@@ -47,6 +47,11 @@
   - chat-speech-verb-slime
 
 - type: speechVerb
+  id: Felinid
+  speechVerbStrings:
+  - chat-speech-verb-felinid
+
+- type: speechVerb
   id: LargeMob
   speechVerbStrings:
   - chat-speech-verb-large-mob


### PR DESCRIPTION
Leap component now has the options requiresGravity and requiresGrounded

if requiresGravity is set to true, leaps will not work unless the entity is under the effects of gravity or magboots.

if requiresGrounded is set to true, leaps will not work unless there is ground beneath the entity that attempted it.

The defaults for these values are,
requiresGravity: false
requiresGrounded: true

Felinids follow the default values.

Felinids also now have their own speech verbs.